### PR TITLE
#48 Fix quote error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ SRC := main.c \
 	   preprocess.c \
 	   tokenize.c \
 	   check_syntax.c \
-	   check_char.c
+	   check_char.c \
+	   operate_list.c \
+	   signal_handler.c
 SRCS := $(addprefix $(SRC_DIR)/,$(notdir $(SRC)))
 
 OBJ_DIR := ./.objects

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ SRC_DIR := ./srcs
 SRC := main.c \
 	   preprocess.c \
 	   tokenize.c \
-	   check_syntax.c
+	   check_syntax.c \
+	   check_char.c
 SRCS := $(addprefix $(SRC_DIR)/,$(notdir $(SRC)))
 
 OBJ_DIR := ./.objects

--- a/srcs/check_char.c
+++ b/srcs/check_char.c
@@ -1,0 +1,18 @@
+#include "minishell.h"
+
+int	is_metacharacter(char c)
+{
+	return (c == ' ' || c == '\n' || c == '\t'
+		|| c == '|' || c == '<' || c == '>'
+		|| c == '(' || c == ')' || c == ';');
+}
+
+int	is_quotes(char c)
+{
+	return (c == '\'' || c == '\"');
+}
+
+int	is_separating_character(char c)
+{
+	return (is_metacharacter(c) || is_quotes(c));
+}

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -1,21 +1,5 @@
 #include "minishell.h"
 
-void	sigint_handler(int sig)
-{
-	printf("sig: %d\n", sig);
-	rl_replace_line("", 0);
-	rl_on_new_line();
-	rl_redisplay();
-}
-
-void	sigquit_handler(int sig)
-{
-	printf("sig: %d\n", sig);
-	rl_replace_line("", 0);
-	rl_on_new_line();
-	rl_redisplay();
-}
-
 int	check_builtin(char *command)
 {
 	if (!ft_strncmp(command, "echo", 5))
@@ -30,8 +14,9 @@ int	run_command(char *command, char *envp[])
 	int		status;
 	pid_t	pid;
 	char	*path;
-	char	*argv[] = {NULL, NULL};
+	char	**argv;
 
+	argv = NULL;
 	argv[0] = command;
 	if (check_builtin(command) == 1)
 	{
@@ -58,6 +43,15 @@ int	run_command(char *command, char *envp[])
 	return (0);
 }
 
+void	init_sigaction(struct sigaction	*sa_sigint,
+	struct sigaction *sa_sigquit)
+{
+	ft_bzero(sa_sigint, sizeof(*sa_sigint));
+	ft_bzero(sa_sigquit, sizeof(*sa_sigquit));
+	sa_sigint->sa_handler = sigint_handler;
+	sa_sigquit->sa_handler = sigquit_handler;
+}
+
 void	minishell(char *envp[])
 {
 	char				*input;
@@ -66,10 +60,7 @@ void	minishell(char *envp[])
 
 	(void)envp;
 	input = NULL;
-	ft_bzero(&sa_sigint, sizeof(sa_sigint));
-	ft_bzero(&sa_sigquit, sizeof(sa_sigquit));
-	sa_sigint.sa_handler = sigint_handler;
-	sa_sigquit.sa_handler = sigquit_handler;
+	init_sigaction(&sa_sigint, &sa_sigquit);
 	while (TRUE)
 	{
 		if (sigaction(SIGINT, &sa_sigint, NULL) < 0)

--- a/srcs/minishell.h
+++ b/srcs/minishell.h
@@ -37,11 +37,16 @@ typedef struct s_command
 	struct s_command	*next;
 }	t_command;
 
-void		tokenize(char *line, t_list **token_list);
-int			preprocess(char *input);
-int			check_syntax(t_list *token_list);
-int			is_metacharacter(char c);
-int			is_quotes(char c);
-int			is_separating_character(char c);
+int				preprocess(char *input);
+int				check_syntax(t_list *token_list);
+int				is_metacharacter(char c);
+int				is_quotes(char c);
+int				is_separating_character(char c);
+int				ft_lstadd_node(t_list **token_list, t_command *new_token);
+void			tokenize(char *line, t_list **token_list);
+void			sigint_handler(int sig);
+void			sigquit_handler(int sig);
+t_token_kind	decide_attr(char *line, int pos);
+t_command		*make_token(t_command *token, char *line, size_t pos, int i);
 
 #endif

--- a/srcs/minishell.h
+++ b/srcs/minishell.h
@@ -25,8 +25,8 @@ typedef enum e_token_kind
 	TK_REDIRECT_MULTI,
 	TK_REDIRECT_APPEND,
 	TK_PARENTHESIS,
-	TK_SINGLE_QUOTE,
-	TK_DOUBLE_QUOTE,
+	TK_SINGLE_QUOTED,
+	TK_DOUBLE_QUOTED,
 	TK_SEMICOLON
 }	t_token_kind;
 
@@ -40,5 +40,8 @@ typedef struct s_command
 void		tokenize(char *line, t_list **token_list);
 int			preprocess(char *input);
 int			check_syntax(t_list *token_list);
+int			is_metacharacter(char c);
+int			is_quotes(char c);
+int			is_separating_character(char c);
 
 #endif

--- a/srcs/operate_list.c
+++ b/srcs/operate_list.c
@@ -1,0 +1,21 @@
+#include "minishell.h"
+
+t_command	*make_token(t_command *token, char *line, size_t pos, int i)
+{
+	token->content = ft_substr(line, pos, i);
+	if (token->attr != TK_SINGLE_QUOTED && token->attr != TK_DOUBLE_QUOTED)
+		token->attr = decide_attr(line, pos);
+	token->next = NULL;
+	return (token);
+}
+
+int	ft_lstadd_node(t_list **token_list, t_command *new_token)
+{
+	t_list	*new_node;
+
+	new_node = ft_lstnew(new_token);
+	if (new_node == NULL)
+		return (FAIL);
+	ft_lstadd_back(token_list, new_node);
+	return (SUCCESS);
+}

--- a/srcs/signal_handler.c
+++ b/srcs/signal_handler.c
@@ -2,7 +2,8 @@
 
 void	sigint_handler(int sig)
 {
-	printf("sig: %d\n", sig);
+	(void)sig;
+	printf("\n");
 	rl_replace_line("", 0);
 	rl_on_new_line();
 	rl_redisplay();
@@ -10,7 +11,7 @@ void	sigint_handler(int sig)
 
 void	sigquit_handler(int sig)
 {
-	printf("sig: %d\n", sig);
+	(void)sig;
 	rl_replace_line("", 0);
 	rl_on_new_line();
 	rl_redisplay();

--- a/srcs/signal_handler.c
+++ b/srcs/signal_handler.c
@@ -1,0 +1,17 @@
+#include "minishell.h"
+
+void	sigint_handler(int sig)
+{
+	printf("sig: %d\n", sig);
+	rl_replace_line("", 0);
+	rl_on_new_line();
+	rl_redisplay();
+}
+
+void	sigquit_handler(int sig)
+{
+	printf("sig: %d\n", sig);
+	rl_replace_line("", 0);
+	rl_on_new_line();
+	rl_redisplay();
+}

--- a/srcs/tokenize.c
+++ b/srcs/tokenize.c
@@ -1,22 +1,5 @@
 #include "minishell.h"
 
-int	is_metacharacter(char c)
-{
-	return (c == ' ' || c == '\n' || c == '\t'
-		|| c == '|' || c == '<' || c == '>'
-		|| c == '(' || c == ')' || c == ';');
-}
-
-int	is_quotes(char c)
-{
-	return (c == '\'' || c == '\"');
-}
-
-int	is_separating_character(char c)
-{
-	return (is_metacharacter(c) || is_quotes(c));
-}
-
 t_token_kind	decide_attr(char *line, int pos)
 {
 	t_token_kind	token_kind;
@@ -33,10 +16,6 @@ t_token_kind	decide_attr(char *line, int pos)
 		token_kind = TK_REDIRECT_IN;
 	else if (line[pos] == '>')
 		token_kind = TK_REDIRECT_OUT;
-	else if (line[pos] == '\'')
-		token_kind = TK_SINGLE_QUOTE;
-	else if (line[pos] == '\"')
-		token_kind = TK_DOUBLE_QUOTE;
 	else if (line[pos] == ';')
 		token_kind = TK_SEMICOLON;
 	else
@@ -44,37 +23,73 @@ t_token_kind	decide_attr(char *line, int pos)
 	return (token_kind);
 }
 
+t_command	*make_token(t_command *token, char *line, size_t pos, int i)
+{
+	token->content = ft_substr(line, pos, i + 1);
+	if (token->attr != TK_SINGLE_QUOTED && token->attr != TK_DOUBLE_QUOTED)
+		token->attr = decide_attr(line, pos);
+	token->next = NULL;
+	return (token);
+}
+
+t_command	*check_quote(char *line, size_t pos, size_t *i,
+	t_command *token)
+{
+	while (line[pos + *i] != line[pos] && line[pos + *i])
+		(*i)++;
+	if (line[pos + *i] == line[pos] && line[pos] == '\'')
+		token->attr = TK_SINGLE_QUOTED;
+	else if (line[pos + *i] == line[pos] && line[pos] == '\"')
+		token->attr = TK_DOUBLE_QUOTED;
+	else
+		token->attr = TK_WORD;
+	token = make_token(token, line, pos, *i);
+	return (token);
+}
+
+int	ft_lstadd_node(t_list **token_list, t_command *new_token)
+{
+	t_list	*new_node;
+
+	new_node = ft_lstnew(new_token);
+	if (new_node == NULL)
+		return (FAIL);
+	ft_lstadd_back(token_list, new_node);
+	return (SUCCESS);
+}
+
 int	store_operator(char *line, t_list **token_list, size_t pos)
 {
 	size_t		i;
-	t_list		*new_node;
 	t_command	*new_token;
 
 	i = 1;
 	new_token = (t_command *)malloc(sizeof(t_command));
 	if (new_token == NULL)
 		return (FAIL);
-	if ((line[pos] == '<' && line[pos + i] == '<')
+	if (line[pos] == '\'' || line[pos] == '\"')
+	{
+		new_token = check_quote(line, pos, &i, new_token);
+		if (ft_lstadd_node(token_list, new_token) == FAIL)
+			return (FAIL);
+		return (pos + i);
+	}
+	else if ((line[pos] == '<' && line[pos + i] == '<')
 		|| (line[pos] == '>' && line[pos + i] == '>'))
-		new_token->content = ft_substr(line, pos, i + 1);
+		new_token = make_token(new_token, line, pos, i + 1);
 	else
 	{
-		new_token->content = ft_substr(line, pos, i);
+		new_token = make_token(new_token, line, pos, i);
 		i = 0;
 	}
-	new_token->attr = decide_attr(line, pos);
-	new_token->next = NULL;
-	new_node = ft_lstnew(new_token);
-	if (new_node == NULL)
+	if (ft_lstadd_node(token_list, new_token) == FAIL)
 		return (FAIL);
-	ft_lstadd_back(token_list, new_node);
 	return (pos + i);
 }
 
 int	store_word(char *line, t_list **token_list, size_t pos)
 {
 	size_t		i;
-	t_list		*new_node;
 	t_command	*new_token;
 
 	i = 0;
@@ -87,13 +102,9 @@ int	store_word(char *line, t_list **token_list, size_t pos)
 			break ;
 		i++;
 	}
-	new_token->content = ft_substr(line, pos, i);
-	new_token->attr = decide_attr(line, pos);
-	new_token->next = NULL;
-	new_node = ft_lstnew(new_token);
-	if (new_node == NULL)
+	new_token = make_token(new_token, line, pos, i);
+	if (ft_lstadd_node(token_list, new_token) == FAIL)
 		return (FAIL);
-	ft_lstadd_back(token_list, new_node);
 	return (pos + i);
 }
 

--- a/srcs/tokenize.c
+++ b/srcs/tokenize.c
@@ -25,7 +25,7 @@ t_token_kind	decide_attr(char *line, int pos)
 
 t_command	*make_token(t_command *token, char *line, size_t pos, int i)
 {
-	token->content = ft_substr(line, pos, i + 1);
+	token->content = ft_substr(line, pos, i);
 	if (token->attr != TK_SINGLE_QUOTED && token->attr != TK_DOUBLE_QUOTED)
 		token->attr = decide_attr(line, pos);
 	token->next = NULL;
@@ -43,7 +43,7 @@ t_command	*check_quote(char *line, size_t pos, size_t *i,
 		token->attr = TK_DOUBLE_QUOTED;
 	else
 		token->attr = TK_WORD;
-	token = make_token(token, line, pos, *i);
+	token = make_token(token, line, pos, *i + 1);
 	return (token);
 }
 

--- a/srcs/tokenize.c
+++ b/srcs/tokenize.c
@@ -58,7 +58,10 @@ int	store_operator(char *line, t_list **token_list, size_t pos)
 		|| (line[pos] == '>' && line[pos + i] == '>'))
 		new_token->content = ft_substr(line, pos, i + 1);
 	else
+	{
 		new_token->content = ft_substr(line, pos, i);
+		i = 0;
+	}
 	new_token->attr = decide_attr(line, pos);
 	new_token->next = NULL;
 	new_node = ft_lstnew(new_token);

--- a/srcs/tokenize.c
+++ b/srcs/tokenize.c
@@ -23,15 +23,6 @@ t_token_kind	decide_attr(char *line, int pos)
 	return (token_kind);
 }
 
-t_command	*make_token(t_command *token, char *line, size_t pos, int i)
-{
-	token->content = ft_substr(line, pos, i);
-	if (token->attr != TK_SINGLE_QUOTED && token->attr != TK_DOUBLE_QUOTED)
-		token->attr = decide_attr(line, pos);
-	token->next = NULL;
-	return (token);
-}
-
 t_command	*check_quote(char *line, size_t pos, size_t *i,
 	t_command *token)
 {
@@ -45,17 +36,6 @@ t_command	*check_quote(char *line, size_t pos, size_t *i,
 		token->attr = TK_WORD;
 	token = make_token(token, line, pos, *i + 1);
 	return (token);
-}
-
-int	ft_lstadd_node(t_list **token_list, t_command *new_token)
-{
-	t_list	*new_node;
-
-	new_node = ft_lstnew(new_token);
-	if (new_node == NULL)
-		return (FAIL);
-	ft_lstadd_back(token_list, new_node);
-	return (SUCCESS);
 }
 
 int	store_operator(char *line, t_list **token_list, size_t pos)

--- a/test.sh
+++ b/test.sh
@@ -40,4 +40,4 @@ do
 	eval ${line} | tee -a test/result/test_syntax_checker.txt
 done < test/test_case/test_syntax_checker.txt
 diff test/result/test_syntax_checker.txt test/answer/test_syntax_checker.txt
-check_result "syntax checker"
+check_result "syntax"

--- a/test/answer/test_tokenizer.txt
+++ b/test/answer/test_tokenizer.txt
@@ -1,43 +1,43 @@
 minishell> a | b
-content: a  attr: 0
-content: |  attr: 2
+content: a attr: 0
+content: | attr: 2
 content: b attr: 0
 minishell> minishell> a > b
-content: a  attr: 0
-content: >  attr: 4
+content: a attr: 0
+content: > attr: 4
 content: b attr: 0
 minishell> minishell> a < b
-content: a  attr: 0
-content: <  attr: 3
+content: a attr: 0
+content: < attr: 3
 content: b attr: 0
 minishell> minishell> a >> b
-content: a  attr: 0
-content: >>  attr: 6
+content: a attr: 0
+content: >> attr: 6
 content: b attr: 0
 minishell> minishell> a << b
-content: a  attr: 0
-content: <<  attr: 5
+content: a attr: 0
+content: << attr: 5
 content: b attr: 0
 minishell> minishell> a ; b
-content: a  attr: 0
-content: ;  attr: 10
+content: a attr: 0
+content: ; attr: 10
 content: b attr: 0
 minishell> minishell> echo "abc"
-content: echo  attr: 0
+content: echo attr: 0
 content: "abc" attr: 9
 minishell> minishell> echo "abc
-content: echo  attr: 0
+content: echo attr: 0
 content: "abc attr: 0
 minishell> minishell> echo abc"
-content: echo  attr: 0
+content: echo attr: 0
 content: abc" attr: 0
 minishell> minishell> echo 'abc'
-content: echo  attr: 0
+content: echo attr: 0
 content: 'abc' attr: 8
 minishell> minishell> echo 'abc
-content: echo  attr: 0
+content: echo attr: 0
 content: 'abc attr: 0
 minishell> minishell> echo abc'
-content: echo  attr: 0
+content: echo attr: 0
 content: abc' attr: 0
 minishell> 

--- a/test/answer/test_tokenizer.txt
+++ b/test/answer/test_tokenizer.txt
@@ -1,33 +1,43 @@
 minishell> a | b
-content: a attr: 0
-content: | attr: 2
+content: a  attr: 0
+content: |  attr: 2
 content: b attr: 0
 minishell> minishell> a > b
-content: a attr: 0
-content: > attr: 4
+content: a  attr: 0
+content: >  attr: 4
 content: b attr: 0
 minishell> minishell> a < b
-content: a attr: 0
-content: < attr: 3
+content: a  attr: 0
+content: <  attr: 3
 content: b attr: 0
 minishell> minishell> a >> b
-content: a attr: 0
-content: >> attr: 6
+content: a  attr: 0
+content: >>  attr: 6
 content: b attr: 0
 minishell> minishell> a << b
-content: a attr: 0
-content: << attr: 5
+content: a  attr: 0
+content: <<  attr: 5
 content: b attr: 0
 minishell> minishell> a ; b
-content: a attr: 0
-content: ; attr: 10
+content: a  attr: 0
+content: ;  attr: 10
 content: b attr: 0
 minishell> minishell> echo "abc"
-content: echo attr: 0
-content: " attr: 9
+content: echo  attr: 0
+content: "abc" attr: 9
+minishell> minishell> echo "abc
+content: echo  attr: 0
+content: "abc attr: 0
+minishell> minishell> echo abc"
+content: echo  attr: 0
 content: abc" attr: 0
 minishell> minishell> echo 'abc'
-content: echo attr: 0
-content: ' attr: 8
+content: echo  attr: 0
+content: 'abc' attr: 8
+minishell> minishell> echo 'abc
+content: echo  attr: 0
+content: 'abc attr: 0
+minishell> minishell> echo abc'
+content: echo  attr: 0
 content: abc' attr: 0
 minishell> 

--- a/test/answer/test_tokenizer.txt
+++ b/test/answer/test_tokenizer.txt
@@ -22,4 +22,12 @@ minishell> minishell> a ; b
 content: a attr: 0
 content: ; attr: 10
 content: b attr: 0
+minishell> minishell> echo "abc"
+content: echo attr: 0
+content: " attr: 9
+content: abc" attr: 0
+minishell> minishell> echo 'abc'
+content: echo attr: 0
+content: ' attr: 8
+content: abc' attr: 0
 minishell> 

--- a/test/test_case/test_tokenizer.txt
+++ b/test/test_case/test_tokenizer.txt
@@ -5,4 +5,8 @@ echo "a >> b" | ./minishell
 echo "a << b" | ./minishell
 echo "a ; b" | ./minishell
 echo 'echo "abc"' | ./minishell
+echo 'echo "abc' | ./minishell
+echo 'echo abc"' | ./minishell
 echo "echo 'abc'" | ./minishell
+echo "echo 'abc" | ./minishell
+echo "echo abc'" | ./minishell

--- a/test/test_case/test_tokenizer.txt
+++ b/test/test_case/test_tokenizer.txt
@@ -4,3 +4,5 @@ echo "a < b" | ./minishell
 echo "a >> b" | ./minishell
 echo "a << b" | ./minishell
 echo "a ; b" | ./minishell
+echo 'echo "abc"' | ./minishell
+echo "echo 'abc'" | ./minishell


### PR DESCRIPTION
I will fix a bug where the first character of a string enclosed in quotes was lost.
when run below command,
`echo "abc"`
the result is
`minishell> echo "abc"
content: echo attr: 0
content: " attr: 9
content: bc" attr: 0`
