### PR TITLE
#73 Add tokenize process when there is a delimiter in the environment variable

### DIFF
--- a/ bbb 
+++ b/ bbb 
@@ -1,0 +1,9 @@
+~~~~~After tokenize~~~~~
+content: " "aaa attr: 0
+content: > attr: 4
+content: " "bbb" " attr: 0
+~~~~~After expand~~~~~
+content:  aaa attr: 0
+content: > attr: 4
+content:  bbb  attr: 0
+minishell:  aaa: command not found

--- a/ bbb 
+++ b/ bbb 
@@ -1,9 +1,0 @@
-~~~~~After tokenize~~~~~
-content: " "aaa attr: 0
-content: > attr: 4
-content: " "bbb" " attr: 0
-~~~~~After expand~~~~~
-content:  aaa attr: 0
-content: > attr: 4
-content:  bbb  attr: 0
-minishell:  aaa: command not found

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -26,8 +26,6 @@ typedef enum e_token_kind
 	TK_REDIRECT_OUT,
 	TK_REDIRECT_DLESS,
 	TK_REDIRECT_DGREAT,
-	TK_SINGLE_QUOTED = 8,
-	TK_DOUBLE_QUOTED,
 	TK_SEMICOLON,
 }	t_token_kind;
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -140,10 +140,10 @@ int				separate_by_null_char(char *line, t_list **token_list,
 
 int				check_syntax(t_list *token_list);
 
-char			*expand_env_vals(t_expand_state *expand_state, t_envs *envs);
+char			*expand_env_vals(t_expand_state *e_state, t_envs *envs);
 
 int				expand(t_list *token_lst, t_list **expanded_lst, t_envs *envs);
-void			init_expand_state(t_expand_state *expand_state);
+void			init_expand_state(t_expand_state *e_state);
 
 t_node			*parse(t_list **token_list);
 int				is_command_token(t_list **token_list);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -64,7 +64,7 @@ typedef struct s_expand_state
 	size_t			start;
 	size_t			current_pos;
 	t_quote_state	quote_state;
-	t_token			*expanded_token;
+	t_token			*origin_token;
 }	t_expand_state;
 
 typedef struct s_node

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -114,6 +114,8 @@ int				is_separating_word(char *line, int pos);
 
 t_token			*make_token(char *line, size_t pos, size_t len, t_token_kind a);
 int				ft_lstadd_node(t_list **token_list, t_token *new_token);
+int				ft_lstadd_word(t_list **lst, char *new_word);
+void			ft_lstadd_last(t_list **lst, t_list *new);
 
 void			do_piping(int pipes[2], t_node *node, t_global_state *state);
 void			close_pipes(int pipes[2], t_node *node, t_global_state *state);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -158,16 +158,16 @@ char			**construct_argv(t_list *tokens, t_global_state *state);
 
 char			*search(char *path, t_envs *envs);
 
-int				is_special_builtin_command(char **argv, t_envs **envs);
-int				is_builtin_command(char **argv, t_envs *envs);
+int				is_special_builtin_command(char **argv, t_envs **envs, int *exit_status);
+int				is_builtin_command(char **argv, t_envs *envs, int *exit_status);
 
-int				ft_echo(char **argv, t_envs *envs);
-int				ft_cd(char **argv, t_envs **envs);
-int				ft_pwd(char **argv, t_envs *envs);
-int				ft_export(char **argv, t_envs **envs);
-int				ft_unset(char **argv, t_envs **envs);
-int				ft_env(char **argv, t_envs *envs);
-int				ft_exit(char **argv, t_envs **envs);
+int				ft_echo(char **argv, t_envs *envs, int *exit_status);
+int				ft_cd(char **argv, t_envs **envs, int *exit_status);
+int				ft_pwd(char **argv, t_envs *envs, int *exit_status);
+int				ft_export(char **argv, t_envs **envs, int *exit_status);
+int				ft_unset(char **argv, t_envs **envs, int *exit_status);
+int				ft_env(char **argv, t_envs *envs, int *exit_status);
+int				ft_exit(char **argv, t_envs **envs, int *exit_status);
 
 void			exit_with_error(char *msg);
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -62,7 +62,7 @@ typedef struct s_expand_state
 	size_t			start;
 	size_t			current_pos;
 	t_quote_state	quote_state;
-	t_token			*origin_token;
+	t_token			*original_token;
 	t_list			*token_list;
 }	t_expand_state;
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -141,9 +141,11 @@ int				separate_by_null_char(char *line, t_list **token_list,
 
 int				check_syntax(t_list *token_list);
 
-int				expand_env_vals(t_expand_state *e_state, t_envs *envs);
+int				expand_env_vals(t_expand_state *e_state, t_envs *envs,
+					int exit_status);
 
-int				expand(t_list *token_lst, t_list **expanded_lst, t_envs *envs);
+int				expand(t_list *token_lst, t_list **expanded_lst, t_envs *envs,
+					int exit_status);
 void			init_expand_state(t_expand_state *e_state);
 
 t_node			*parse(t_list **token_list);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -63,6 +63,7 @@ typedef struct s_expand_state
 	size_t			current_pos;
 	t_quote_state	quote_state;
 	t_token			*origin_token;
+	t_list			*token_list;
 }	t_expand_state;
 
 typedef struct s_node

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -139,7 +139,7 @@ int				separate_by_null_char(char *line, t_list **token_list,
 
 int				check_syntax(t_list *token_list);
 
-char			*expand_env_vals(t_expand_state *e_state, t_envs *envs);
+int				expand_env_vals(t_expand_state *e_state, t_envs *envs);
 
 int				expand(t_list *token_lst, t_list **expanded_lst, t_envs *envs);
 void			init_expand_state(t_expand_state *e_state);

--- a/srcs/builtins/cd.c
+++ b/srcs/builtins/cd.c
@@ -1,8 +1,9 @@
 #include "minishell.h"
 
-int	ft_cd(char **argv, t_envs **envs)
+int	ft_cd(char **argv, t_envs **envs, int *exit_status)
 {
 	(void)envs;
+	(void)exit_status;
 	if (chdir(argv[1]) == FAIL)
 		exit_with_error(argv[1]);
 	return (SUCCESS);

--- a/srcs/builtins/echo.c
+++ b/srcs/builtins/echo.c
@@ -1,11 +1,12 @@
 #include "minishell.h"
 
-int	ft_echo(char **argv, t_envs *envs)
+int	ft_echo(char **argv, t_envs *envs, int *exit_status)
 {
 	int		has_n_option;
 	size_t	i;
 
 	(void)envs;
+	(void)exit_status;
 	if (argv[1] != NULL && !ft_strncmp(argv[1], "-n", 3))
 	{
 		has_n_option = TRUE;

--- a/srcs/builtins/env.c
+++ b/srcs/builtins/env.c
@@ -1,9 +1,10 @@
 #include "minishell.h"
 
-int	ft_env(char **argv, t_envs *envs)
+int	ft_env(char **argv, t_envs *envs, int *exit_status)
 {
 	size_t	i;
 
+	(void)exit_status;
 	if (argv[1] == NULL)
 	{
 		i = 0;

--- a/srcs/builtins/exit.c
+++ b/srcs/builtins/exit.c
@@ -1,10 +1,11 @@
 #include "minishell.h"
 
-int	ft_exit(char **argv, t_envs **envs)
+int	ft_exit(char **argv, t_envs **envs, int *exit_state)
 {
 	int		exit_status;
 
 	(void)envs;
+	(void)exit_state;
 	ft_putendl_fd("exit", 1);
 	if (argv[1] == NULL)
 		exit(EXIT_SUCCESS); // TODO: use global state

--- a/srcs/builtins/export.c
+++ b/srcs/builtins/export.c
@@ -102,8 +102,9 @@ int	set_new_env_to_envs(char **argv, t_envs **envs)
 	return (SUCCESS);
 }
 
-int	ft_export(char **argv, t_envs **envs)
+int	ft_export(char **argv, t_envs **envs, int *exit_status)
 {
+	(void)exit_status;
 	if (argv[1] == NULL)
 	{
 		if (print_envs(*envs) == FAIL)

--- a/srcs/builtins/is_builtin.c
+++ b/srcs/builtins/is_builtin.c
@@ -1,11 +1,11 @@
 #include "minishell.h"
 
-int	is_special_builtin_command(char **argv, t_envs **envs)
+int	is_special_builtin_command(char **argv, t_envs **envs, int *exit_status)
 {
 	int		ret;
 	size_t	i;
 	char *builtins[] = {"cd", "export", "unset", "exit", NULL};
-	int (*builtin_funcs[])(char **, t_envs **) = {ft_cd, ft_export, ft_unset, ft_exit};
+	int (*builtin_funcs[])(char **, t_envs **, int *) = {ft_cd, ft_export, ft_unset, ft_exit};
 
 	i = 0;
 	if (argv[0] == NULL)
@@ -14,7 +14,7 @@ int	is_special_builtin_command(char **argv, t_envs **envs)
 	{
 		if (!ft_strncmp(argv[0], builtins[i], ft_strlen(builtins[i]) + 1))
 		{
-			ret = builtin_funcs[i](argv, envs);
+			ret = builtin_funcs[i](argv, envs, exit_status);
 			(void)ret;  // TODO: use ret value
 			return (TRUE);
 		}
@@ -23,19 +23,19 @@ int	is_special_builtin_command(char **argv, t_envs **envs)
 	return (FALSE);
 }
 
-int	is_builtin_command(char **argv, t_envs *envs)
+int	is_builtin_command(char **argv, t_envs *envs, int *exit_status)
 {
 	int		ret;
 	size_t	i;
 	char *builtins[] = {"echo", "pwd", "env", NULL};
-	int (*builtin_funcs[])(char **, t_envs *) = {ft_echo, ft_pwd, ft_env};
+	int (*builtin_funcs[])(char **, t_envs *, int *) = {ft_echo, ft_pwd, ft_env};
 
 	i = 0;
 	while (builtins[i])
 	{
 		if (!ft_strncmp(argv[0], builtins[i], ft_strlen(builtins[i]) + 1))
 		{
-			ret = builtin_funcs[i](argv, envs);
+			ret = builtin_funcs[i](argv, envs, exit_status);
 			(void)ret;  // TODO: use ret value
 			return (TRUE);
 		}

--- a/srcs/builtins/pwd.c
+++ b/srcs/builtins/pwd.c
@@ -2,7 +2,7 @@
 
 #define BUF_SIZE 1024
 
-int	ft_pwd(char **argv, t_envs *envs)
+int	ft_pwd(char **argv, t_envs *envs, int *exit_status)
 {
 	int		count;
 	char	*buf;
@@ -10,6 +10,7 @@ int	ft_pwd(char **argv, t_envs *envs)
 
 	(void)argv;
 	(void)envs;
+	(void)exit_status;
 	count = 1;
 	while (TRUE)
 	{

--- a/srcs/builtins/unset.c
+++ b/srcs/builtins/unset.c
@@ -26,11 +26,12 @@ int	remove_env(int index, t_envs **envs)
 	return (SUCCESS);
 }
 
-int	ft_unset(char **argv, t_envs **envs)
+int	ft_unset(char **argv, t_envs **envs, int *exit_status)
 {
 	int	index;
 	size_t	i;
 
+	(void)exit_status;
 	if (argv[1] != NULL)
 	{
 		i = 1;

--- a/srcs/execute/execute.c
+++ b/srcs/execute/execute.c
@@ -12,7 +12,7 @@ void	execute_command(char **argv, t_global_state *state)
 			dup2(state->redirects[i]->file_fd, state->redirects[i]->redirect_fd);
 		i++;
 	}
-	if (is_builtin_command(argv, state->envs))
+	if (is_builtin_command(argv, state->envs, &(state->last_command_exit_status)))
 		exit(errno);
 	else
 	{
@@ -52,7 +52,7 @@ int	execute_commands(t_node *node, int pipes[2], t_global_state *state)
 
 	argv = construct_argv(node->tokens, state);
 	close_pipes(pipes, node, state);
-	if (is_special_builtin_command(argv, &(state->envs)))
+	if (is_special_builtin_command(argv, &(state->envs), &(state->last_command_exit_status)))
 		return (SUCCESS);
 	pid = fork();
 	if (pid < 0)

--- a/srcs/expand/expand.c
+++ b/srcs/expand/expand.c
@@ -64,6 +64,7 @@ int	expand(t_list *token_list, t_list **expanded_list, t_envs *envs)
 		// TODO: Add process when there is a delimiter in the environment variable
 		// if (e_state.origin_token->attr == TK_WORD)
 			// tokenize()
+		// TODO: I want to use ft_lstadd_back instead of ft_lstadd_node function
 		if (ft_lstadd_node(expanded_list, e_state.origin_token) == FAIL)
 			return (FAIL);
 		token_list = token_list->next;

--- a/srcs/expand/expand.c
+++ b/srcs/expand/expand.c
@@ -33,11 +33,9 @@ void	remove_quote(t_expand_state *e_state)
 	init_expand_state(e_state);
 	while (e_state->expanded_token->content[e_state->current_pos])
 	{
-		if (e_state->expanded_token
-			->content[e_state->current_pos] == '\'')
+		if (e_state->expanded_token->content[e_state->current_pos] == '\'')
 			update_state_with_quote(e_state, IN_QUOTE, &quote_removed);
-		else if (e_state->expanded_token
-			->content[e_state->current_pos] == '\"')
+		else if (e_state->expanded_token->content[e_state->current_pos] == '\"')
 			update_state_with_quote(e_state, IN_DQUOTE, &quote_removed);
 		else if (e_state->quote_state == NORMAL)
 			quote_removed = ft_strjoin(quote_removed,
@@ -56,15 +54,13 @@ int	expand(t_list *token_list, t_list **expanded_list, t_envs *envs)
 	while (token_list != NULL)
 	{
 		e_state.expanded_token = (t_token *)malloc(sizeof(t_token));
-		e_state.expanded_token->attr
-			= ((t_token *)token_list->content)->attr;
+		e_state.expanded_token->attr = ((t_token *)token_list->content)->attr;
 		e_state.expanded_token->content
 			= ((t_token *)token_list->content)->content;
 		if ((e_state.expanded_token->attr == TK_WORD
 				|| e_state.expanded_token->attr == TK_DOUBLE_QUOTED)
 			&& ft_strchr(e_state.expanded_token->content, '$') != NULL)
-			e_state.expanded_token->content
-				= expand_env_vals(&e_state, envs);
+			e_state.expanded_token->content = expand_env_vals(&e_state, envs);
 		remove_quote(&e_state);
 		if (ft_lstadd_node(expanded_list, e_state.expanded_token) == FAIL)
 			return (FAIL);

--- a/srcs/expand/expand.c
+++ b/srcs/expand/expand.c
@@ -60,10 +60,9 @@ int	expand(t_list *token_list, t_list **expanded_list, t_envs *envs)
 			= ((t_token *)token_list->content)->content;
 		if (ft_strchr(e_state.origin_token->content, '$') != NULL)
 			e_state.origin_token->content = expand_env_vals(&e_state, envs);
+		else
+			ft_lstadd_node(&(e_state.token_list), e_state.origin_token);
 		remove_quote(&e_state);
-		// TODO: Add process when there is a delimiter in the environment variable
-		// if (e_state.origin_token->attr == TK_WORD)
-			// tokenize()
 		// TODO: I want to use ft_lstadd_back instead of ft_lstadd_node function
 		if (ft_lstadd_node(expanded_list, e_state.origin_token) == FAIL)
 			return (FAIL);

--- a/srcs/expand/expand.c
+++ b/srcs/expand/expand.c
@@ -18,7 +18,7 @@ void	update_state_with_quote(t_expand_state *e_state,
 	else if (e_state->quote_state == quote_state)
 	{
 		*quote_removed = ft_strjoin(*quote_removed,
-				ft_substr(e_state->expanded_token->content,
+				ft_substr(e_state->origin_token->content,
 					e_state->start + 1,
 					e_state->current_pos - e_state->start - 1));
 		e_state->quote_state = NORMAL;
@@ -31,19 +31,19 @@ void	remove_quote(t_expand_state *e_state)
 
 	quote_removed = ft_strdup("");
 	init_expand_state(e_state);
-	while (e_state->expanded_token->content[e_state->current_pos])
+	while (e_state->origin_token->content[e_state->current_pos])
 	{
-		if (e_state->expanded_token->content[e_state->current_pos] == '\'')
+		if (e_state->origin_token->content[e_state->current_pos] == '\'')
 			update_state_with_quote(e_state, IN_QUOTE, &quote_removed);
-		else if (e_state->expanded_token->content[e_state->current_pos] == '\"')
+		else if (e_state->origin_token->content[e_state->current_pos] == '\"')
 			update_state_with_quote(e_state, IN_DQUOTE, &quote_removed);
 		else if (e_state->quote_state == NORMAL)
 			quote_removed = ft_strjoin(quote_removed,
-					ft_substr(e_state->expanded_token->content,
+					ft_substr(e_state->origin_token->content,
 						e_state->current_pos, 1));
 		e_state->current_pos++;
 	}
-	e_state->expanded_token->content = quote_removed;
+	e_state->origin_token->content = quote_removed;
 }
 
 int	expand(t_list *token_list, t_list **expanded_list, t_envs *envs)
@@ -53,16 +53,16 @@ int	expand(t_list *token_list, t_list **expanded_list, t_envs *envs)
 	init_expand_state(&e_state);
 	while (token_list != NULL)
 	{
-		e_state.expanded_token = (t_token *)malloc(sizeof(t_token));
-		e_state.expanded_token->attr = ((t_token *)token_list->content)->attr;
-		e_state.expanded_token->content
+		e_state.origin_token = (t_token *)malloc(sizeof(t_token));
+		e_state.origin_token->attr = ((t_token *)token_list->content)->attr;
+		e_state.origin_token->content
 			= ((t_token *)token_list->content)->content;
-		if ((e_state.expanded_token->attr == TK_WORD
-				|| e_state.expanded_token->attr == TK_DOUBLE_QUOTED)
-			&& ft_strchr(e_state.expanded_token->content, '$') != NULL)
-			e_state.expanded_token->content = expand_env_vals(&e_state, envs);
+		if ((e_state.origin_token->attr == TK_WORD
+				|| e_state.origin_token->attr == TK_DOUBLE_QUOTED)
+			&& ft_strchr(e_state.origin_token->content, '$') != NULL)
+			e_state.origin_token->content = expand_env_vals(&e_state, envs);
 		remove_quote(&e_state);
-		if (ft_lstadd_node(expanded_list, e_state.expanded_token) == FAIL)
+		if (ft_lstadd_node(expanded_list, e_state.origin_token) == FAIL)
 			return (FAIL);
 		token_list = token_list->next;
 	}

--- a/srcs/expand/expand.c
+++ b/srcs/expand/expand.c
@@ -47,13 +47,14 @@ t_token	*remove_quote(t_expand_state *e_state)
 						e_state->current_pos, 1));
 		e_state->current_pos++;
 	}
-	q_removed = make_token(quote_removed, 0, ft_strlen(quote_removed), token->attr);
+	q_removed = make_token(quote_removed, 0, ft_strlen(quote_removed),
+			token->attr);
 	return (q_removed);
 }
 
 int	expand(t_list *token_list, t_list **expanded_list, t_envs *envs)
 {
-	t_token	*q_removed;
+	t_token			*q_removed;
 	t_expand_state	e_state;
 
 	init_expand_state(&e_state);

--- a/srcs/expand/expand.c
+++ b/srcs/expand/expand.c
@@ -1,72 +1,72 @@
 #include "minishell.h"
 
-void	init_expand_state(t_expand_state *expand_state)
+void	init_expand_state(t_expand_state *e_state)
 {
-	expand_state->start = 0;
-	expand_state->current_pos = 0;
-	expand_state->quote_state = NORMAL;
+	e_state->start = 0;
+	e_state->current_pos = 0;
+	e_state->quote_state = NORMAL;
 }
 
-void	update_state_with_quote(t_expand_state *expand_state,
+void	update_state_with_quote(t_expand_state *e_state,
 		t_quote_state quote_state, char **quote_removed)
 {
-	if (expand_state->quote_state == NORMAL)
+	if (e_state->quote_state == NORMAL)
 	{
-		expand_state->quote_state = quote_state;
-		expand_state->start = expand_state->current_pos;
+		e_state->quote_state = quote_state;
+		e_state->start = e_state->current_pos;
 	}
-	else if (expand_state->quote_state == quote_state)
+	else if (e_state->quote_state == quote_state)
 	{
 		*quote_removed = ft_strjoin(*quote_removed,
-				ft_substr(expand_state->expanded_token->content,
-					expand_state->start + 1,
-					expand_state->current_pos - expand_state->start - 1));
-		expand_state->quote_state = NORMAL;
+				ft_substr(e_state->expanded_token->content,
+					e_state->start + 1,
+					e_state->current_pos - e_state->start - 1));
+		e_state->quote_state = NORMAL;
 	}
 }
 
-void	remove_quote(t_expand_state *expand_state)
+void	remove_quote(t_expand_state *e_state)
 {
 	char	*quote_removed;
 
 	quote_removed = ft_strdup("");
-	init_expand_state(expand_state);
-	while (expand_state->expanded_token->content[expand_state->current_pos])
+	init_expand_state(e_state);
+	while (e_state->expanded_token->content[e_state->current_pos])
 	{
-		if (expand_state->expanded_token
-			->content[expand_state->current_pos] == '\'')
-			update_state_with_quote(expand_state, IN_QUOTE, &quote_removed);
-		else if (expand_state->expanded_token
-			->content[expand_state->current_pos] == '\"')
-			update_state_with_quote(expand_state, IN_DQUOTE, &quote_removed);
-		else if (expand_state->quote_state == NORMAL)
+		if (e_state->expanded_token
+			->content[e_state->current_pos] == '\'')
+			update_state_with_quote(e_state, IN_QUOTE, &quote_removed);
+		else if (e_state->expanded_token
+			->content[e_state->current_pos] == '\"')
+			update_state_with_quote(e_state, IN_DQUOTE, &quote_removed);
+		else if (e_state->quote_state == NORMAL)
 			quote_removed = ft_strjoin(quote_removed,
-					ft_substr(expand_state->expanded_token->content,
-						expand_state->current_pos, 1));
-		expand_state->current_pos++;
+					ft_substr(e_state->expanded_token->content,
+						e_state->current_pos, 1));
+		e_state->current_pos++;
 	}
-	expand_state->expanded_token->content = quote_removed;
+	e_state->expanded_token->content = quote_removed;
 }
 
 int	expand(t_list *token_list, t_list **expanded_list, t_envs *envs)
 {
-	t_expand_state	expand_state;
+	t_expand_state	e_state;
 
-	init_expand_state(&expand_state);
+	init_expand_state(&e_state);
 	while (token_list != NULL)
 	{
-		expand_state.expanded_token = (t_token *)malloc(sizeof(t_token));
-		expand_state.expanded_token->attr
+		e_state.expanded_token = (t_token *)malloc(sizeof(t_token));
+		e_state.expanded_token->attr
 			= ((t_token *)token_list->content)->attr;
-		expand_state.expanded_token->content
+		e_state.expanded_token->content
 			= ((t_token *)token_list->content)->content;
-		if ((expand_state.expanded_token->attr == TK_WORD
-				|| expand_state.expanded_token->attr == TK_DOUBLE_QUOTED)
-			&& ft_strchr(expand_state.expanded_token->content, '$') != NULL)
-			expand_state.expanded_token->content
-				= expand_env_vals(&expand_state, envs);
-		remove_quote(&expand_state);
-		if (ft_lstadd_node(expanded_list, expand_state.expanded_token) == FAIL)
+		if ((e_state.expanded_token->attr == TK_WORD
+				|| e_state.expanded_token->attr == TK_DOUBLE_QUOTED)
+			&& ft_strchr(e_state.expanded_token->content, '$') != NULL)
+			e_state.expanded_token->content
+				= expand_env_vals(&e_state, envs);
+		remove_quote(&e_state);
+		if (ft_lstadd_node(expanded_list, e_state.expanded_token) == FAIL)
 			return (FAIL);
 		token_list = token_list->next;
 	}

--- a/srcs/expand/expand.c
+++ b/srcs/expand/expand.c
@@ -61,14 +61,14 @@ int	expand(t_list *token_list, t_list **expanded_list, t_envs *envs)
 	e_state.token_list = NULL;
 	while (token_list != NULL)
 	{
-		e_state.origin_token = (t_token *)malloc(sizeof(t_token));
-		e_state.origin_token->attr = ((t_token *)token_list->content)->attr;
-		e_state.origin_token->content
+		e_state.original_token = (t_token *)malloc(sizeof(t_token));
+		e_state.original_token->attr = ((t_token *)token_list->content)->attr;
+		e_state.original_token->content
 			= ((t_token *)token_list->content)->content;
-		if (ft_strchr(e_state.origin_token->content, '$') != NULL)
+		if (ft_strchr(e_state.original_token->content, '$') != NULL)
 			expand_env_vals(&e_state, envs);
 		else
-			ft_lstadd_node(&(e_state.token_list), e_state.origin_token);
+			ft_lstadd_node(&(e_state.token_list), e_state.original_token);
 		while (e_state.token_list != NULL)
 		{
 			q_removed = remove_quote(&e_state);

--- a/srcs/expand/expand.c
+++ b/srcs/expand/expand.c
@@ -52,7 +52,8 @@ t_token	*remove_quote(t_expand_state *e_state)
 	return (q_removed);
 }
 
-int	expand(t_list *token_list, t_list **expanded_list, t_envs *envs)
+int	expand(t_list *token_list, t_list **expanded_list, t_envs *envs,
+	int exit_status)
 {
 	t_token			*q_removed;
 	t_expand_state	e_state;
@@ -66,7 +67,7 @@ int	expand(t_list *token_list, t_list **expanded_list, t_envs *envs)
 		e_state.original_token->content
 			= ((t_token *)token_list->content)->content;
 		if (ft_strchr(e_state.original_token->content, '$') != NULL)
-			expand_env_vals(&e_state, envs);
+			expand_env_vals(&e_state, envs, exit_status);
 		else
 			ft_lstadd_node(&(e_state.token_list), e_state.original_token);
 		while (e_state.token_list != NULL)

--- a/srcs/expand/expand.c
+++ b/srcs/expand/expand.c
@@ -7,7 +7,7 @@ void	init_expand_state(t_expand_state *e_state)
 	e_state->quote_state = NORMAL;
 }
 
-void	update_state_with_quote(t_expand_state *e_state,
+void	update_state_with_quote(t_expand_state *e_state, t_token *token,
 		t_quote_state quote_state, char **quote_removed)
 {
 	if (e_state->quote_state == NORMAL)
@@ -18,7 +18,7 @@ void	update_state_with_quote(t_expand_state *e_state,
 	else if (e_state->quote_state == quote_state)
 	{
 		*quote_removed = ft_strjoin(*quote_removed,
-				ft_substr(e_state->origin_token->content,
+				ft_substr(token->content,
 					e_state->start + 1,
 					e_state->current_pos - e_state->start - 1));
 		e_state->quote_state = NORMAL;
@@ -38,9 +38,9 @@ t_token	*remove_quote(t_expand_state *e_state)
 	while (token->content[e_state->current_pos])
 	{
 		if (token->content[e_state->current_pos] == '\'')
-			update_state_with_quote(e_state, IN_QUOTE, &quote_removed);
+			update_state_with_quote(e_state, token, IN_QUOTE, &quote_removed);
 		else if (token->content[e_state->current_pos] == '\"')
-			update_state_with_quote(e_state, IN_DQUOTE, &quote_removed);
+			update_state_with_quote(e_state, token, IN_DQUOTE, &quote_removed);
 		else if (e_state->quote_state == NORMAL)
 			quote_removed = ft_strjoin(quote_removed,
 					ft_substr(token->content,
@@ -65,7 +65,7 @@ int	expand(t_list *token_list, t_list **expanded_list, t_envs *envs)
 		e_state.origin_token->content
 			= ((t_token *)token_list->content)->content;
 		if (ft_strchr(e_state.origin_token->content, '$') != NULL)
-			e_state.origin_token->content = expand_env_vals(&e_state, envs);
+			expand_env_vals(&e_state, envs);
 		else
 			ft_lstadd_node(&(e_state.token_list), e_state.origin_token);
 		while (e_state.token_list != NULL)

--- a/srcs/expand/expand.c
+++ b/srcs/expand/expand.c
@@ -57,11 +57,12 @@ int	expand(t_list *token_list, t_list **expanded_list, t_envs *envs)
 		e_state.origin_token->attr = ((t_token *)token_list->content)->attr;
 		e_state.origin_token->content
 			= ((t_token *)token_list->content)->content;
-		if ((e_state.origin_token->attr == TK_WORD
-				|| e_state.origin_token->attr == TK_DOUBLE_QUOTED)
-			&& ft_strchr(e_state.origin_token->content, '$') != NULL)
+		if (ft_strchr(e_state.origin_token->content, '$') != NULL)
 			e_state.origin_token->content = expand_env_vals(&e_state, envs);
 		remove_quote(&e_state);
+		// TODO: Add process when there is a delimiter in the environment variable
+		// if (e_state.origin_token->attr == TK_WORD)
+			// tokenize()
 		if (ft_lstadd_node(expanded_list, e_state.origin_token) == FAIL)
 			return (FAIL);
 		token_list = token_list->next;

--- a/srcs/expand/expand.c
+++ b/srcs/expand/expand.c
@@ -51,6 +51,7 @@ int	expand(t_list *token_list, t_list **expanded_list, t_envs *envs)
 	t_expand_state	e_state;
 
 	init_expand_state(&e_state);
+	e_state.token_list = NULL;
 	while (token_list != NULL)
 	{
 		e_state.origin_token = (t_token *)malloc(sizeof(t_token));

--- a/srcs/expand/expand_env_vals.c
+++ b/srcs/expand/expand_env_vals.c
@@ -34,6 +34,20 @@ void	check_diff_between_start_and_curernt_pos(
 					e_state->start, e_state->current_pos - e_state->start));
 }
 
+void	ft_lstadd_last(t_list **lst, t_list *new)
+{
+	t_list	*last_lst;
+
+	if (!*lst)
+	{
+		*lst = new;
+		return ;
+	}
+	last_lst = ft_lstlast(*lst);
+	new->prev = last_lst;
+	last_lst->next = new;
+}
+
 char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
 {
 	char	*name;
@@ -43,7 +57,6 @@ char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
 	t_list	*tmp_list;
 	t_list	*last_list;
 
-	// TODO: Remove tmp
 	init_expand_state(e_state);
 	tmp = ft_strdup("");
 	while (e_state->origin_token->content[e_state->current_pos])
@@ -80,10 +93,11 @@ char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
 					{
 						tmp_list = NULL;
 						tokenize(value, &tmp_list);
-						ft_lstadd_back(&(e_state->token_list), tmp_list);
+						// ft_lstadd_back(&(e_state->token_list), tmp_list);
+						ft_lstadd_last(&(e_state->token_list), tmp_list);
 					}
 					else
-					{	
+					{
 						new_token = make_token(value, 0, ft_strlen(value), TK_WORD);
 						if (ft_lstadd_node(&(e_state->token_list), new_token) == FAIL)
 							return (NULL);

--- a/srcs/expand/expand_env_vals.c
+++ b/srcs/expand/expand_env_vals.c
@@ -3,19 +3,14 @@
 char	*get_name_after_dollar(t_expand_state *e_state, size_t start)
 {
 	while (e_state->expanded_token->content[e_state->current_pos]
-		&& e_state->expanded_token
-		->content[e_state->current_pos] != ' '
-		&& e_state->expanded_token
-		->content[e_state->current_pos] != '$'
-		&& e_state->expanded_token
-		->content[e_state->current_pos] != '\''
-		&& e_state->expanded_token
-		->content[e_state->current_pos] != '\"'
+		&& e_state->expanded_token->content[e_state->current_pos] != ' '
+		&& e_state->expanded_token->content[e_state->current_pos] != '$'
+		&& e_state->expanded_token->content[e_state->current_pos] != '\''
+		&& e_state->expanded_token->content[e_state->current_pos] != '\"'
 	)
 	{
 		e_state->current_pos++;
-		if (e_state->expanded_token->content[e_state->current_pos - 1]
-			== '?')
+		if (e_state->expanded_token->content[e_state->current_pos - 1] == '?')
 		{
 			// TODO: Correspond $?
 			printf("$? appeared\n");
@@ -36,8 +31,7 @@ void	check_diff_between_start_and_curernt_pos(
 	if (e_state->start != e_state->current_pos)
 		*expanded = ft_strjoin(*expanded,
 				ft_substr(e_state->expanded_token->content,
-					e_state->start,
-					e_state->current_pos - e_state->start));
+					e_state->start, e_state->current_pos - e_state->start));
 }
 
 char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
@@ -50,8 +44,7 @@ char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
 	expanded = ft_strdup("");
 	while (e_state->expanded_token->content[e_state->current_pos])
 	{
-		if (e_state->expanded_token
-			->content[e_state->current_pos] == '$')
+		if (e_state->expanded_token->content[e_state->current_pos] == '$')
 		{
 			check_diff_between_start_and_curernt_pos(e_state, &expanded);
 			e_state->current_pos++;

--- a/srcs/expand/expand_env_vals.c
+++ b/srcs/expand/expand_env_vals.c
@@ -47,17 +47,10 @@ int	ft_lstadd_word(t_list **lst, char *new_word)
 	return (SUCCESS);
 }
 
-void	check_diff_between_start_and_curernt_pos(
-	t_expand_state *e_state,
-	char **expanded
-)
+void	check_diff_between_start_and_curernt_pos(t_expand_state *e_state)
 {
 	if (e_state->start != e_state->current_pos)
-		*expanded = ft_strjoin(*expanded,
-				ft_substr(e_state->origin_token->content,
-					e_state->start, e_state->current_pos - e_state->start));
-	ft_lstadd_word(&(e_state->token_list), ft_substr(e_state->origin_token->content,
-					e_state->start, e_state->current_pos - e_state->start));
+		ft_lstadd_word(&(e_state->token_list), ft_substr(e_state->origin_token->content, e_state->start, e_state->current_pos - e_state->start));
 }
 
 void	ft_lstadd_last(t_list **lst, t_list *new)
@@ -86,15 +79,13 @@ void	ft_lstadd_last(t_list **lst, t_list *new)
 		last_lst->next = NULL;
 }
 
-char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
+int	expand_env_vals(t_expand_state *e_state, t_envs *envs)
 {
 	char	*name;
 	char	*value;
-	char	*tmp;
 	t_list	*tmp_list;
 
 	init_expand_state(e_state);
-	tmp = ft_strdup("");
 	while (e_state->origin_token->content[e_state->current_pos])
 	{
 		update_quote_state(&(e_state->quote_state),
@@ -102,14 +93,11 @@ char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
 		if (e_state->origin_token->content[e_state->current_pos] == '$'
 			&& e_state->quote_state != IN_QUOTE)
 		{
-			check_diff_between_start_and_curernt_pos(e_state, &tmp);
+			check_diff_between_start_and_curernt_pos(e_state);
 			e_state->current_pos++;
 			name = get_name_after_dollar(e_state, e_state->current_pos);
 			if (ft_strncmp(name, "$", ft_strlen(name) + 1) == 0)
-			{
 				ft_lstadd_word(&(e_state->token_list), name);
-				tmp = ft_strjoin(tmp, name);
-			}
 			else
 			{
 				value = get_env(name, envs);
@@ -123,7 +111,6 @@ char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
 					}
 					else
 						ft_lstadd_word(&(e_state->token_list), value);
-					tmp = ft_strjoin(tmp, value);
 				}
 			}
 			e_state->start = e_state->current_pos;
@@ -131,6 +118,6 @@ char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
 		}
 		e_state->current_pos++;
 	}
-	check_diff_between_start_and_curernt_pos(e_state, &tmp);
-	return (tmp);
+	check_diff_between_start_and_curernt_pos(e_state);
+	return (SUCCESS);
 }

--- a/srcs/expand/expand_env_vals.c
+++ b/srcs/expand/expand_env_vals.c
@@ -38,10 +38,14 @@ char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
 {
 	char	*name;
 	char	*value;
-	char	*expanded;
+	char	*tmp;
+	t_token	*new_token;
+	t_list	*tmp_list;
+	t_list	*last_list;
 
+	// TODO: Remove tmp
 	init_expand_state(e_state);
-	expanded = ft_strdup("");
+	tmp = ft_strdup("");
 	while (e_state->origin_token->content[e_state->current_pos])
 	{
 		update_quote_state(&(e_state->quote_state),
@@ -49,22 +53,94 @@ char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
 		if (e_state->origin_token->content[e_state->current_pos] == '$'
 			&& e_state->quote_state != IN_QUOTE)
 		{
-			check_diff_between_start_and_curernt_pos(e_state, &expanded);
+			check_diff_between_start_and_curernt_pos(e_state, &tmp);
 			e_state->current_pos++;
 			name = get_name_after_dollar(e_state, e_state->current_pos);
 			if (ft_strncmp(name, "$", ft_strlen(name) + 1) == 0)
-				expanded = ft_strjoin(expanded, name);
+			{
+				last_list = ft_lstlast(e_state->token_list);
+				// TODO: Make function
+				if (last_list != NULL)
+					last_list->content = ft_strjoin(last_list->content, name);
+				else
+				{
+					new_token = make_token(name, 0, ft_strlen(name), TK_WORD);
+					if (ft_lstadd_node(&(e_state->token_list), new_token) == FAIL)
+						return (NULL);
+				}
+				tmp = ft_strjoin(tmp, name);
+			}
 			else
 			{
 				value = get_env(name, envs);
+				// printf("value: %s\n", value);
 				if (value != NULL)
-					expanded = ft_strjoin(expanded, value);
+				{
+					if (e_state->quote_state == NORMAL)
+					{
+						tmp_list = NULL;
+						tokenize(value, &tmp_list);
+						ft_lstadd_back(&(e_state->token_list), tmp_list);
+					}
+					else
+					{	
+						new_token = make_token(value, 0, ft_strlen(value), TK_WORD);
+						if (ft_lstadd_node(&(e_state->token_list), new_token) == FAIL)
+							return (NULL);
+					}
+					// printf("~~~after_tokenize~~~\n");
+					// ft_lstiter(e_state->token_list, output_result);
+					tmp = ft_strjoin(tmp, value);
+				}
 			}
 			e_state->start = e_state->current_pos;
 			continue ;
 		}
 		e_state->current_pos++;
 	}
-	check_diff_between_start_and_curernt_pos(e_state, &expanded);
-	return (expanded);
+	printf("~~~after_tokenize~~~\n");
+	ft_lstiter(e_state->token_list, output_result);
+	check_diff_between_start_and_curernt_pos(e_state, &tmp);
+	return (tmp);
 }
+
+// char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
+// {
+// 	char	*name;
+// 	char	*value;
+// 	char	*expanded;
+
+// 	init_expand_state(e_state);
+// 	expanded = ft_strdup("");
+// 	while (e_state->origin_token->content[e_state->current_pos])
+// 	{
+// 		update_quote_state(&(e_state->quote_state),
+// 			e_state->origin_token->content[e_state->current_pos]);
+// 		if (e_state->origin_token->content[e_state->current_pos] == '$'
+// 			&& e_state->quote_state != IN_QUOTE)
+// 		{
+// 			check_diff_between_start_and_curernt_pos(e_state, &expanded);
+// 			e_state->current_pos++;
+// 			name = get_name_after_dollar(e_state, e_state->current_pos);
+// 			if (ft_strncmp(name, "$", ft_strlen(name) + 1) == 0)
+// 				expanded = ft_strjoin(expanded, name);
+// 			else
+// 			{
+// 				value = get_env(name, envs);
+// 				printf("value: %s\n", value);
+// 				if (value != NULL)
+// 				{
+// 					tokenize(value, &(e_state->token_list));
+// 					printf("~~~after_tokenize~~~\n");
+// 					ft_lstiter(e_state->token_list, output_result);
+// 					expanded = ft_strjoin(expanded, value);
+// 				}
+// 			}
+// 			e_state->start = e_state->current_pos;
+// 			continue ;
+// 		}
+// 		e_state->current_pos++;
+// 	}
+// 	check_diff_between_start_and_curernt_pos(e_state, &expanded);
+// 	return (expanded);
+// }

--- a/srcs/expand/expand_env_vals.c
+++ b/srcs/expand/expand_env_vals.c
@@ -11,11 +11,7 @@ char	*get_name_after_dollar(t_expand_state *e_state, size_t start)
 	{
 		e_state->current_pos++;
 		if (e_state->original_token->content[e_state->current_pos - 1] == '?')
-		{
-			// TODO: Correspond $?
-			printf("$? appeared\n");
-			continue ;
-		}
+			return (ft_strdup("$?"));
 	}
 	if (e_state->current_pos == start)
 		return (ft_strdup("$"));
@@ -50,11 +46,18 @@ void	get_value_and_insert(char *name, t_envs *envs, t_expand_state *e_state)
 	}
 }
 
-int	check_name(char *name, t_envs *envs, t_expand_state *e_state)
+int	check_name(char *name, t_envs *envs, t_expand_state *e_state,
+	int exit_status)
 {
 	if (ft_strncmp(name, "$", ft_strlen(name) + 1) == 0)
 	{
 		if (ft_lstadd_word(&(e_state->token_list), name) == FAIL)
+			return (FAIL);
+	}
+	else if (ft_strncmp(name, "$?", ft_strlen(name) + 1) == 0)
+	{
+		if (ft_lstadd_word(&(e_state->token_list),
+				ft_itoa(exit_status)) == FAIL)
 			return (FAIL);
 	}
 	else
@@ -62,7 +65,7 @@ int	check_name(char *name, t_envs *envs, t_expand_state *e_state)
 	return (SUCCESS);
 }
 
-int	expand_env_vals(t_expand_state *e_state, t_envs *envs)
+int	expand_env_vals(t_expand_state *e_state, t_envs *envs, int exit_status)
 {
 	char	*name;
 
@@ -77,7 +80,7 @@ int	expand_env_vals(t_expand_state *e_state, t_envs *envs)
 			check_diff_between_start_and_curernt_pos(e_state);
 			e_state->current_pos++;
 			name = get_name_after_dollar(e_state, e_state->current_pos);
-			if (check_name(name, envs, e_state) == FAIL)
+			if (check_name(name, envs, e_state, exit_status) == FAIL)
 				return (FAIL);
 			e_state->start = e_state->current_pos;
 			continue ;

--- a/srcs/expand/expand_env_vals.c
+++ b/srcs/expand/expand_env_vals.c
@@ -2,15 +2,15 @@
 
 char	*get_name_after_dollar(t_expand_state *e_state, size_t start)
 {
-	while (e_state->origin_token->content[e_state->current_pos]
-		&& e_state->origin_token->content[e_state->current_pos] != ' '
-		&& e_state->origin_token->content[e_state->current_pos] != '$'
-		&& e_state->origin_token->content[e_state->current_pos] != '\''
-		&& e_state->origin_token->content[e_state->current_pos] != '\"'
+	while (e_state->original_token->content[e_state->current_pos]
+		&& e_state->original_token->content[e_state->current_pos] != ' '
+		&& e_state->original_token->content[e_state->current_pos] != '$'
+		&& e_state->original_token->content[e_state->current_pos] != '\''
+		&& e_state->original_token->content[e_state->current_pos] != '\"'
 	)
 	{
 		e_state->current_pos++;
-		if (e_state->origin_token->content[e_state->current_pos - 1] == '?')
+		if (e_state->original_token->content[e_state->current_pos - 1] == '?')
 		{
 			// TODO: Correspond $?
 			printf("$? appeared\n");
@@ -19,7 +19,7 @@ char	*get_name_after_dollar(t_expand_state *e_state, size_t start)
 	}
 	if (e_state->current_pos == start)
 		return (ft_strdup("$"));
-	return (ft_substr(e_state->origin_token->content,
+	return (ft_substr(e_state->original_token->content,
 			start, e_state->current_pos - start));
 }
 
@@ -27,7 +27,7 @@ void	check_diff_between_start_and_curernt_pos(t_expand_state *e_state)
 {
 	if (e_state->start != e_state->current_pos)
 		ft_lstadd_word(&(e_state->token_list),
-			ft_substr(e_state->origin_token->content, e_state->start,
+			ft_substr(e_state->original_token->content, e_state->start,
 				e_state->current_pos - e_state->start));
 }
 
@@ -67,11 +67,11 @@ int	expand_env_vals(t_expand_state *e_state, t_envs *envs)
 	char	*name;
 
 	init_expand_state(e_state);
-	while (e_state->origin_token->content[e_state->current_pos])
+	while (e_state->original_token->content[e_state->current_pos])
 	{
 		update_quote_state(&(e_state->quote_state),
-			e_state->origin_token->content[e_state->current_pos]);
-		if (e_state->origin_token->content[e_state->current_pos] == '$'
+			e_state->original_token->content[e_state->current_pos]);
+		if (e_state->original_token->content[e_state->current_pos] == '$'
 			&& e_state->quote_state != IN_QUOTE)
 		{
 			check_diff_between_start_and_curernt_pos(e_state);

--- a/srcs/expand/expand_env_vals.c
+++ b/srcs/expand/expand_env_vals.c
@@ -61,6 +61,7 @@ char	*expand_env_vals(t_expand_state *expand_state, t_envs *envs)
 			else
 			{
 				value = get_env(name, envs);
+				// TODO: Add process when there is a delimiter in the environment variable
 				if (value != NULL)
 					expanded = ft_strjoin(expanded, value);
 			}

--- a/srcs/expand/expand_env_vals.c
+++ b/srcs/expand/expand_env_vals.c
@@ -2,15 +2,15 @@
 
 char	*get_name_after_dollar(t_expand_state *e_state, size_t start)
 {
-	while (e_state->expanded_token->content[e_state->current_pos]
-		&& e_state->expanded_token->content[e_state->current_pos] != ' '
-		&& e_state->expanded_token->content[e_state->current_pos] != '$'
-		&& e_state->expanded_token->content[e_state->current_pos] != '\''
-		&& e_state->expanded_token->content[e_state->current_pos] != '\"'
+	while (e_state->origin_token->content[e_state->current_pos]
+		&& e_state->origin_token->content[e_state->current_pos] != ' '
+		&& e_state->origin_token->content[e_state->current_pos] != '$'
+		&& e_state->origin_token->content[e_state->current_pos] != '\''
+		&& e_state->origin_token->content[e_state->current_pos] != '\"'
 	)
 	{
 		e_state->current_pos++;
-		if (e_state->expanded_token->content[e_state->current_pos - 1] == '?')
+		if (e_state->origin_token->content[e_state->current_pos - 1] == '?')
 		{
 			// TODO: Correspond $?
 			printf("$? appeared\n");
@@ -19,7 +19,7 @@ char	*get_name_after_dollar(t_expand_state *e_state, size_t start)
 	}
 	if (e_state->current_pos == start)
 		return (ft_strdup("$"));
-	return (ft_substr(e_state->expanded_token->content,
+	return (ft_substr(e_state->origin_token->content,
 			start, e_state->current_pos - start));
 }
 
@@ -30,7 +30,7 @@ void	check_diff_between_start_and_curernt_pos(
 {
 	if (e_state->start != e_state->current_pos)
 		*expanded = ft_strjoin(*expanded,
-				ft_substr(e_state->expanded_token->content,
+				ft_substr(e_state->origin_token->content,
 					e_state->start, e_state->current_pos - e_state->start));
 }
 
@@ -42,9 +42,9 @@ char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
 
 	init_expand_state(e_state);
 	expanded = ft_strdup("");
-	while (e_state->expanded_token->content[e_state->current_pos])
+	while (e_state->origin_token->content[e_state->current_pos])
 	{
-		if (e_state->expanded_token->content[e_state->current_pos] == '$')
+		if (e_state->origin_token->content[e_state->current_pos] == '$')
 		{
 			check_diff_between_start_and_curernt_pos(e_state, &expanded);
 			e_state->current_pos++;

--- a/srcs/expand/expand_env_vals.c
+++ b/srcs/expand/expand_env_vals.c
@@ -1,20 +1,20 @@
 #include "minishell.h"
 
-char	*get_name_after_dollar(t_expand_state *expand_state, size_t start)
+char	*get_name_after_dollar(t_expand_state *e_state, size_t start)
 {
-	while (expand_state->expanded_token->content[expand_state->current_pos]
-		&& expand_state->expanded_token
-		->content[expand_state->current_pos] != ' '
-		&& expand_state->expanded_token
-		->content[expand_state->current_pos] != '$'
-		&& expand_state->expanded_token
-		->content[expand_state->current_pos] != '\''
-		&& expand_state->expanded_token
-		->content[expand_state->current_pos] != '\"'
+	while (e_state->expanded_token->content[e_state->current_pos]
+		&& e_state->expanded_token
+		->content[e_state->current_pos] != ' '
+		&& e_state->expanded_token
+		->content[e_state->current_pos] != '$'
+		&& e_state->expanded_token
+		->content[e_state->current_pos] != '\''
+		&& e_state->expanded_token
+		->content[e_state->current_pos] != '\"'
 	)
 	{
-		expand_state->current_pos++;
-		if (expand_state->expanded_token->content[expand_state->current_pos - 1]
+		e_state->current_pos++;
+		if (e_state->expanded_token->content[e_state->current_pos - 1]
 			== '?')
 		{
 			// TODO: Correspond $?
@@ -22,40 +22,40 @@ char	*get_name_after_dollar(t_expand_state *expand_state, size_t start)
 			continue ;
 		}
 	}
-	if (expand_state->current_pos == start)
+	if (e_state->current_pos == start)
 		return (ft_strdup("$"));
-	return (ft_substr(expand_state->expanded_token->content,
-			start, expand_state->current_pos - start));
+	return (ft_substr(e_state->expanded_token->content,
+			start, e_state->current_pos - start));
 }
 
 void	check_diff_between_start_and_curernt_pos(
-	t_expand_state *expand_state,
+	t_expand_state *e_state,
 	char **expanded
 )
 {
-	if (expand_state->start != expand_state->current_pos)
+	if (e_state->start != e_state->current_pos)
 		*expanded = ft_strjoin(*expanded,
-				ft_substr(expand_state->expanded_token->content,
-					expand_state->start,
-					expand_state->current_pos - expand_state->start));
+				ft_substr(e_state->expanded_token->content,
+					e_state->start,
+					e_state->current_pos - e_state->start));
 }
 
-char	*expand_env_vals(t_expand_state *expand_state, t_envs *envs)
+char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
 {
 	char	*name;
 	char	*value;
 	char	*expanded;
 
-	init_expand_state(expand_state);
+	init_expand_state(e_state);
 	expanded = ft_strdup("");
-	while (expand_state->expanded_token->content[expand_state->current_pos])
+	while (e_state->expanded_token->content[e_state->current_pos])
 	{
-		if (expand_state->expanded_token
-			->content[expand_state->current_pos] == '$')
+		if (e_state->expanded_token
+			->content[e_state->current_pos] == '$')
 		{
-			check_diff_between_start_and_curernt_pos(expand_state, &expanded);
-			expand_state->current_pos++;
-			name = get_name_after_dollar(expand_state, expand_state->current_pos);
+			check_diff_between_start_and_curernt_pos(e_state, &expanded);
+			e_state->current_pos++;
+			name = get_name_after_dollar(e_state, e_state->current_pos);
 			if (ft_strncmp(name, "$", ft_strlen(name) + 1) == 0)
 				expanded = ft_strjoin(expanded, name);
 			else
@@ -65,11 +65,11 @@ char	*expand_env_vals(t_expand_state *expand_state, t_envs *envs)
 				if (value != NULL)
 					expanded = ft_strjoin(expanded, value);
 			}
-			expand_state->start = expand_state->current_pos;
+			e_state->start = e_state->current_pos;
 			continue ;
 		}
-		expand_state->current_pos++;
+		e_state->current_pos++;
 	}
-	check_diff_between_start_and_curernt_pos(expand_state, &expanded);
+	check_diff_between_start_and_curernt_pos(e_state, &expanded);
 	return (expanded);
 }

--- a/srcs/expand/expand_env_vals.c
+++ b/srcs/expand/expand_env_vals.c
@@ -23,6 +23,30 @@ char	*get_name_after_dollar(t_expand_state *e_state, size_t start)
 			start, e_state->current_pos - start));
 }
 
+int	ft_lstadd_word(t_list **lst, char *new_word)
+{
+	t_list	*last_lst;
+	t_token	*new_token;
+	t_token	*last_token;
+
+	if (!*lst)
+	{
+		new_token = make_token(new_word, 0, ft_strlen(new_word), TK_WORD);
+		if (ft_lstadd_node(lst, new_token) == FAIL)
+			return (FAIL);
+		return (SUCCESS);
+	}
+	else
+	{
+		last_lst = ft_lstlast(*lst);
+		last_token = (t_token *)last_lst->content;
+		last_token->content = ft_strjoin(last_token->content, new_word);
+		if (last_token->content == NULL)
+			return (FAIL);
+	}
+	return (SUCCESS);
+}
+
 void	check_diff_between_start_and_curernt_pos(
 	t_expand_state *e_state,
 	char **expanded
@@ -32,11 +56,16 @@ void	check_diff_between_start_and_curernt_pos(
 		*expanded = ft_strjoin(*expanded,
 				ft_substr(e_state->origin_token->content,
 					e_state->start, e_state->current_pos - e_state->start));
+	ft_lstadd_word(&(e_state->token_list), ft_substr(e_state->origin_token->content,
+					e_state->start, e_state->current_pos - e_state->start));
 }
 
 void	ft_lstadd_last(t_list **lst, t_list *new)
 {
 	t_list	*last_lst;
+	t_token	*new_token;
+	t_token	*last_token;
+	char	*new_word;
 
 	if (!*lst)
 	{
@@ -44,8 +73,17 @@ void	ft_lstadd_last(t_list **lst, t_list *new)
 		return ;
 	}
 	last_lst = ft_lstlast(*lst);
-	new->prev = last_lst;
-	last_lst->next = new;
+	new_token = (t_token *)new->content;
+	new_word = new_token->content;
+	last_token = (t_token *)last_lst->content;
+	last_token->content = ft_strjoin(last_token->content, new_word);
+	if (new->next != NULL)
+	{
+		new->next->prev = last_lst;
+		last_lst->next = new->next;
+	}
+	else
+		last_lst->next = NULL;
 }
 
 char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
@@ -53,9 +91,7 @@ char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
 	char	*name;
 	char	*value;
 	char	*tmp;
-	t_token	*new_token;
 	t_list	*tmp_list;
-	t_list	*last_list;
 
 	init_expand_state(e_state);
 	tmp = ft_strdup("");
@@ -71,39 +107,22 @@ char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
 			name = get_name_after_dollar(e_state, e_state->current_pos);
 			if (ft_strncmp(name, "$", ft_strlen(name) + 1) == 0)
 			{
-				last_list = ft_lstlast(e_state->token_list);
-				// TODO: Make function
-				if (last_list != NULL)
-					last_list->content = ft_strjoin(last_list->content, name);
-				else
-				{
-					new_token = make_token(name, 0, ft_strlen(name), TK_WORD);
-					if (ft_lstadd_node(&(e_state->token_list), new_token) == FAIL)
-						return (NULL);
-				}
+				ft_lstadd_word(&(e_state->token_list), name);
 				tmp = ft_strjoin(tmp, name);
 			}
 			else
 			{
 				value = get_env(name, envs);
-				// printf("value: %s\n", value);
 				if (value != NULL)
 				{
 					if (e_state->quote_state == NORMAL)
 					{
 						tmp_list = NULL;
 						tokenize(value, &tmp_list);
-						// ft_lstadd_back(&(e_state->token_list), tmp_list);
 						ft_lstadd_last(&(e_state->token_list), tmp_list);
 					}
 					else
-					{
-						new_token = make_token(value, 0, ft_strlen(value), TK_WORD);
-						if (ft_lstadd_node(&(e_state->token_list), new_token) == FAIL)
-							return (NULL);
-					}
-					// printf("~~~after_tokenize~~~\n");
-					// ft_lstiter(e_state->token_list, output_result);
+						ft_lstadd_word(&(e_state->token_list), value);
 					tmp = ft_strjoin(tmp, value);
 				}
 			}
@@ -112,9 +131,9 @@ char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
 		}
 		e_state->current_pos++;
 	}
+	check_diff_between_start_and_curernt_pos(e_state, &tmp);
 	printf("~~~after_tokenize~~~\n");
 	ft_lstiter(e_state->token_list, output_result);
-	check_diff_between_start_and_curernt_pos(e_state, &tmp);
 	return (tmp);
 }
 

--- a/srcs/expand/expand_env_vals.c
+++ b/srcs/expand/expand_env_vals.c
@@ -44,7 +44,10 @@ char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
 	expanded = ft_strdup("");
 	while (e_state->origin_token->content[e_state->current_pos])
 	{
-		if (e_state->origin_token->content[e_state->current_pos] == '$')
+		update_quote_state(&(e_state->quote_state),
+			e_state->origin_token->content[e_state->current_pos]);
+		if (e_state->origin_token->content[e_state->current_pos] == '$'
+			&& e_state->quote_state != IN_QUOTE)
 		{
 			check_diff_between_start_and_curernt_pos(e_state, &expanded);
 			e_state->current_pos++;
@@ -54,7 +57,6 @@ char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
 			else
 			{
 				value = get_env(name, envs);
-				// TODO: Add process when there is a delimiter in the environment variable
 				if (value != NULL)
 					expanded = ft_strjoin(expanded, value);
 			}

--- a/srcs/expand/expand_env_vals.c
+++ b/srcs/expand/expand_env_vals.c
@@ -132,48 +132,5 @@ char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
 		e_state->current_pos++;
 	}
 	check_diff_between_start_and_curernt_pos(e_state, &tmp);
-	printf("~~~after_tokenize~~~\n");
-	ft_lstiter(e_state->token_list, output_result);
 	return (tmp);
 }
-
-// char	*expand_env_vals(t_expand_state *e_state, t_envs *envs)
-// {
-// 	char	*name;
-// 	char	*value;
-// 	char	*expanded;
-
-// 	init_expand_state(e_state);
-// 	expanded = ft_strdup("");
-// 	while (e_state->origin_token->content[e_state->current_pos])
-// 	{
-// 		update_quote_state(&(e_state->quote_state),
-// 			e_state->origin_token->content[e_state->current_pos]);
-// 		if (e_state->origin_token->content[e_state->current_pos] == '$'
-// 			&& e_state->quote_state != IN_QUOTE)
-// 		{
-// 			check_diff_between_start_and_curernt_pos(e_state, &expanded);
-// 			e_state->current_pos++;
-// 			name = get_name_after_dollar(e_state, e_state->current_pos);
-// 			if (ft_strncmp(name, "$", ft_strlen(name) + 1) == 0)
-// 				expanded = ft_strjoin(expanded, name);
-// 			else
-// 			{
-// 				value = get_env(name, envs);
-// 				printf("value: %s\n", value);
-// 				if (value != NULL)
-// 				{
-// 					tokenize(value, &(e_state->token_list));
-// 					printf("~~~after_tokenize~~~\n");
-// 					ft_lstiter(e_state->token_list, output_result);
-// 					expanded = ft_strjoin(expanded, value);
-// 				}
-// 			}
-// 			e_state->start = e_state->current_pos;
-// 			continue ;
-// 		}
-// 		e_state->current_pos++;
-// 	}
-// 	check_diff_between_start_and_curernt_pos(e_state, &expanded);
-// 	return (expanded);
-// }

--- a/srcs/expand/expand_env_vals.c
+++ b/srcs/expand/expand_env_vals.c
@@ -23,67 +23,48 @@ char	*get_name_after_dollar(t_expand_state *e_state, size_t start)
 			start, e_state->current_pos - start));
 }
 
-int	ft_lstadd_word(t_list **lst, char *new_word)
-{
-	t_list	*last_lst;
-	t_token	*new_token;
-	t_token	*last_token;
-
-	if (!*lst)
-	{
-		new_token = make_token(new_word, 0, ft_strlen(new_word), TK_WORD);
-		if (ft_lstadd_node(lst, new_token) == FAIL)
-			return (FAIL);
-		return (SUCCESS);
-	}
-	else
-	{
-		last_lst = ft_lstlast(*lst);
-		last_token = (t_token *)last_lst->content;
-		last_token->content = ft_strjoin(last_token->content, new_word);
-		if (last_token->content == NULL)
-			return (FAIL);
-	}
-	return (SUCCESS);
-}
-
 void	check_diff_between_start_and_curernt_pos(t_expand_state *e_state)
 {
 	if (e_state->start != e_state->current_pos)
-		ft_lstadd_word(&(e_state->token_list), ft_substr(e_state->origin_token->content, e_state->start, e_state->current_pos - e_state->start));
+		ft_lstadd_word(&(e_state->token_list),
+			ft_substr(e_state->origin_token->content, e_state->start,
+				e_state->current_pos - e_state->start));
 }
 
-void	ft_lstadd_last(t_list **lst, t_list *new)
+void	get_value_and_insert(char *name, t_envs *envs, t_expand_state *e_state)
 {
-	t_list	*last_lst;
-	t_token	*new_token;
-	t_token	*last_token;
-	char	*new_word;
+	char	*value;
+	t_list	*tmp_list;
 
-	if (!*lst)
+	value = get_env(name, envs);
+	if (value != NULL)
 	{
-		*lst = new;
-		return ;
+		if (e_state->quote_state == NORMAL)
+		{
+			tmp_list = NULL;
+			tokenize(value, &tmp_list);
+			ft_lstadd_last(&(e_state->token_list), tmp_list);
+		}
+		else
+			ft_lstadd_word(&(e_state->token_list), value);
 	}
-	last_lst = ft_lstlast(*lst);
-	new_token = (t_token *)new->content;
-	new_word = new_token->content;
-	last_token = (t_token *)last_lst->content;
-	last_token->content = ft_strjoin(last_token->content, new_word);
-	if (new->next != NULL)
+}
+
+int	check_name(char *name, t_envs *envs, t_expand_state *e_state)
+{
+	if (ft_strncmp(name, "$", ft_strlen(name) + 1) == 0)
 	{
-		new->next->prev = last_lst;
-		last_lst->next = new->next;
+		if (ft_lstadd_word(&(e_state->token_list), name) == FAIL)
+			return (FAIL);
 	}
 	else
-		last_lst->next = NULL;
+		get_value_and_insert(name, envs, e_state);
+	return (SUCCESS);
 }
 
 int	expand_env_vals(t_expand_state *e_state, t_envs *envs)
 {
 	char	*name;
-	char	*value;
-	t_list	*tmp_list;
 
 	init_expand_state(e_state);
 	while (e_state->origin_token->content[e_state->current_pos])
@@ -96,23 +77,8 @@ int	expand_env_vals(t_expand_state *e_state, t_envs *envs)
 			check_diff_between_start_and_curernt_pos(e_state);
 			e_state->current_pos++;
 			name = get_name_after_dollar(e_state, e_state->current_pos);
-			if (ft_strncmp(name, "$", ft_strlen(name) + 1) == 0)
-				ft_lstadd_word(&(e_state->token_list), name);
-			else
-			{
-				value = get_env(name, envs);
-				if (value != NULL)
-				{
-					if (e_state->quote_state == NORMAL)
-					{
-						tmp_list = NULL;
-						tokenize(value, &tmp_list);
-						ft_lstadd_last(&(e_state->token_list), tmp_list);
-					}
-					else
-						ft_lstadd_word(&(e_state->token_list), value);
-				}
-			}
+			if (check_name(name, envs, e_state) == FAIL)
+				return (FAIL);
 			e_state->start = e_state->current_pos;
 			continue ;
 		}

--- a/srcs/operate_list.c
+++ b/srcs/operate_list.c
@@ -22,3 +22,53 @@ int	ft_lstadd_node(t_list **token_list, t_token *new_token)
 	ft_lstadd_back(token_list, new_node);
 	return (SUCCESS);
 }
+
+int	ft_lstadd_word(t_list **lst, char *new_word)
+{
+	t_list	*last_lst;
+	t_token	*new_token;
+	t_token	*last_token;
+
+	if (!*lst)
+	{
+		new_token = make_token(new_word, 0, ft_strlen(new_word), TK_WORD);
+		if (ft_lstadd_node(lst, new_token) == FAIL)
+			return (FAIL);
+		return (SUCCESS);
+	}
+	else
+	{
+		last_lst = ft_lstlast(*lst);
+		last_token = (t_token *)last_lst->content;
+		last_token->content = ft_strjoin(last_token->content, new_word);
+		if (last_token->content == NULL)
+			return (FAIL);
+	}
+	return (SUCCESS);
+}
+
+void	ft_lstadd_last(t_list **lst, t_list *new)
+{
+	char	*new_word;
+	t_token	*new_token;
+	t_token	*last_token;
+	t_list	*last_lst;
+
+	if (!*lst)
+	{
+		*lst = new;
+		return ;
+	}
+	last_lst = ft_lstlast(*lst);
+	new_token = (t_token *)new->content;
+	new_word = new_token->content;
+	last_token = (t_token *)last_lst->content;
+	last_token->content = ft_strjoin(last_token->content, new_word);
+	if (new->next != NULL)
+	{
+		new->next->prev = last_lst;
+		last_lst->next = new->next;
+	}
+	else
+		last_lst->next = NULL;
+}

--- a/srcs/parse/parse_utils.c
+++ b/srcs/parse/parse_utils.c
@@ -32,8 +32,6 @@ t_node	*new_node(t_node *lhs, t_node *rhs, t_node_kind attr)
 int	is_command_token(t_list **token_list)
 {
 	return (consume_token(token_list, TK_WORD)
-		|| consume_token(token_list, TK_SINGLE_QUOTED)
-		|| consume_token(token_list, TK_DOUBLE_QUOTED)
 		|| consume_token(token_list, TK_IO_NUMBER)
 		|| consume_token(token_list, TK_REDIRECT_IN)
 		|| consume_token(token_list, TK_REDIRECT_OUT)

--- a/srcs/preprocess.c
+++ b/srcs/preprocess.c
@@ -25,7 +25,8 @@ t_node	*preprocess(char *line, t_global_state *state)
 	printf("~~~~~After tokenize~~~~~\n");
 	ft_lstiter(token_list, output_result);
 	expanded_list = NULL;
-	expand(token_list, &expanded_list, state->envs);
+	expand(token_list, &expanded_list, state->envs,
+		state->last_command_exit_status);
 	printf("~~~~~After expand~~~~~\n");
 	ft_lstiter(expanded_list, output_result);
 	return (parse(&expanded_list));

--- a/srcs/tokenize/get_token_kind.c
+++ b/srcs/tokenize/get_token_kind.c
@@ -1,34 +1,5 @@
 #include "minishell.h"
 
-t_token_kind	get_token_kind_about_quote(t_quote_state state, char c)
-{
-	t_token_kind	token_kind;
-
-	if (c == '\'' && state == NORMAL)
-		token_kind = TK_SINGLE_QUOTED;
-	else if (c == '\"' && state == NORMAL)
-		token_kind = TK_DOUBLE_QUOTED;
-	else
-		token_kind = TK_WORD;
-	return (token_kind);
-}
-
-t_token_kind	check_whether_quoted_word(char *line, int pos, size_t *i)
-{
-	t_token_kind	token_kind;
-
-	while (line[pos + *i] && (line[pos + *i] == ' '
-			|| line[pos + *i] == '\t' || line[pos + *i] == '\n'))
-		*i += 1;
-	if (pos - 1 > 0 && line[pos - 1] == '\'')
-		token_kind = TK_SINGLE_QUOTED;
-	else if (pos - 1 > 0 && line[pos - 1] == '\"')
-		token_kind = TK_DOUBLE_QUOTED;
-	else
-		token_kind = TK_WORD;
-	return (token_kind);
-}
-
 t_token_kind	get_token_kind(char *line, int pos, size_t *i)
 {
 	t_token_kind	token_kind;
@@ -65,7 +36,12 @@ t_token_kind	get_token_kind(char *line, int pos, size_t *i)
 		token_kind = TK_REDIRECT_OUT;
 	}
 	else if (line[pos] == ' ' || line[pos] == '\t' || line[pos] == '\n')
-		token_kind = check_whether_quoted_word(line, pos, i);
+	{
+		while (line[pos + *i] && (line[pos + *i] == ' '
+				|| line[pos + *i] == '\t' || line[pos + *i] == '\n'))
+			*i += 1;
+		token_kind = TK_WORD;
+	}
 	else
 		token_kind = TK_WORD;
 	return (token_kind);

--- a/srcs/tokenize/separate.c
+++ b/srcs/tokenize/separate.c
@@ -35,8 +35,7 @@ int	separate_by_sep_word(char *line, t_list **token_list,
 	{
 		new_token = make_token(line, tokenize_state->trim_start,
 				tokenize_state->current_pos - tokenize_state->trim_start,
-				get_token_kind_about_quote(tokenize_state->quote_state,
-					line[tokenize_state->current_pos - 1]));
+				TK_WORD);
 		if (ft_lstadd_node(token_list, new_token) == FAIL)
 			return (FAIL);
 		tokenize_state->trim_start = tokenize_state->current_pos;
@@ -60,9 +59,7 @@ int	separate_by_null_char(char *line, t_list **token_list,
 	i = 0;
 	tokenize_state->current_pos++;
 	new_token = make_token(line, tokenize_state->trim_start,
-			tokenize_state->current_pos - tokenize_state->trim_start,
-			get_token_kind_about_quote(tokenize_state->quote_state,
-				line[tokenize_state->current_pos - 1]));
+			tokenize_state->current_pos - tokenize_state->trim_start, TK_WORD);
 	if (ft_lstadd_node(token_list, new_token) == FAIL)
 		return (FAIL);
 	tokenize_state->trim_start = tokenize_state->current_pos + i;

--- a/test.sh
+++ b/test.sh
@@ -47,9 +47,6 @@ done
 rm -rf test/result/expand
 mkdir -p test/result/expand
 for fp in `ls test/case/expand`; do
-	if [ $fp = "check_second_tokenize.txt" ]; then
-		continue
-	fi
 	while read line
 	do
 		eval ${line} >> test/result/expand/$fp

--- a/test.sh
+++ b/test.sh
@@ -47,6 +47,9 @@ done
 rm -rf test/result/expand
 mkdir -p test/result/expand
 for fp in `ls test/case/expand`; do
+	if [ $fp = "check_second_tokenize.txt" ]; then
+		continue
+	fi
 	while read line
 	do
 		eval ${line} >> test/result/expand/$fp

--- a/test/answer/expand/check_second_tokenize.txt
+++ b/test/answer/expand/check_second_tokenize.txt
@@ -1,0 +1,7 @@
+minishell> $OUR_MINISHELL
+~~~~~After tokenize~~~~~
+content: $OUR_MINISHELL attr: 0
+~~~~~After expand~~~~~
+content: echo attr: 0
+content: Beatiful attr: 0
+minishell> 

--- a/test/answer/expand/env_val_with_quote.txt
+++ b/test/answer/expand/env_val_with_quote.txt
@@ -1,10 +1,10 @@
 minishell> echo "$OUR_MINISHELL"
 ~~~~~After tokenize~~~~~
 content: echo attr: 0
-content: "$OUR_MINISHELL" attr: 9
+content: "$OUR_MINISHELL" attr: 0
 ~~~~~After expand~~~~~
 content: echo attr: 0
-content: Beatiful attr: 9
+content: Beatiful attr: 0
 minishell> minishell> echo "$"OUR_MINISHELL
 ~~~~~After tokenize~~~~~
 content: echo attr: 0
@@ -15,15 +15,15 @@ content: $OUR_MINISHELL attr: 0
 minishell> minishell> echo "$OUR_MINISHELL$OUR_MINISHELL"
 ~~~~~After tokenize~~~~~
 content: echo attr: 0
-content: "$OUR_MINISHELL$OUR_MINISHELL" attr: 9
+content: "$OUR_MINISHELL$OUR_MINISHELL" attr: 0
 ~~~~~After expand~~~~~
 content: echo attr: 0
-content: BeatifulBeatiful attr: 9
+content: BeatifulBeatiful attr: 0
 minishell> minishell> echo " $OUR_MINISHELL $OUR_MINISHELL "
 ~~~~~After tokenize~~~~~
 content: echo attr: 0
-content: " $OUR_MINISHELL $OUR_MINISHELL " attr: 9
+content: " $OUR_MINISHELL $OUR_MINISHELL " attr: 0
 ~~~~~After expand~~~~~
 content: echo attr: 0
-content:  Beatiful Beatiful  attr: 9
+content:  Beatiful Beatiful  attr: 0
 minishell> 

--- a/test/answer/expand/env_val_without_quote.txt
+++ b/test/answer/expand/env_val_without_quote.txt
@@ -27,14 +27,12 @@ content: echo attr: 0
 content: $OUR_MINISHELLa attr: 0
 ~~~~~After expand~~~~~
 content: echo attr: 0
-content:  attr: 0
 minishell> minishell> echo $aOUR_MINISHELL
 ~~~~~After tokenize~~~~~
 content: echo attr: 0
 content: $aOUR_MINISHELL attr: 0
 ~~~~~After expand~~~~~
 content: echo attr: 0
-content:  attr: 0
 minishell> minishell> echo a$OUR_MINISHELL
 ~~~~~After tokenize~~~~~
 content: echo attr: 0

--- a/test/answer/expand/env_val_without_quote.txt
+++ b/test/answer/expand/env_val_without_quote.txt
@@ -47,4 +47,11 @@ content: a$OUR_MINISHELLa attr: 0
 ~~~~~After expand~~~~~
 content: echo attr: 0
 content: a attr: 0
+minishell> minishell> echo $OUR_MINISHELL$?$OUR_MINISHELL
+~~~~~After tokenize~~~~~
+content: echo attr: 0
+content: $OUR_MINISHELL$?$OUR_MINISHELL attr: 0
+~~~~~After expand~~~~~
+content: echo attr: 0
+content: Beatiful0Beatiful attr: 0
 minishell> 

--- a/test/answer/tokenize/multiple_quoted_word.txt
+++ b/test/answer/tokenize/multiple_quoted_word.txt
@@ -1,25 +1,25 @@
 minishell> "aaa""bbb"
 ~~~~~After tokenize~~~~~
-content: "aaa""bbb" attr: 9
+content: "aaa""bbb" attr: 0
 ~~~~~After expand~~~~~
-content: aaabbb attr: 9
+content: aaabbb attr: 0
 minishell> minishell> 'aaa''bbb'
 ~~~~~After tokenize~~~~~
-content: 'aaa''bbb' attr: 8
+content: 'aaa''bbb' attr: 0
 ~~~~~After expand~~~~~
-content: aaabbb attr: 8
+content: aaabbb attr: 0
 minishell> minishell> ""aaa" "bbb""
 ~~~~~After tokenize~~~~~
-content: ""aaa" "bbb"" attr: 9
+content: ""aaa" "bbb"" attr: 0
 ~~~~~After expand~~~~~
-content: aaa bbb attr: 9
+content: aaa bbb attr: 0
 minishell> minishell> " "aaa>" "bbb" "
 ~~~~~After tokenize~~~~~
 content: " "aaa attr: 0
 content: > attr: 4
-content: " "bbb" " attr: 9
+content: " "bbb" " attr: 0
 ~~~~~After expand~~~~~
 content:  aaa attr: 0
 content: > attr: 4
-content:  bbb  attr: 9
+content:  bbb  attr: 0
 minishell> 

--- a/test/answer/tokenize/simple_command.txt
+++ b/test/answer/tokenize/simple_command.txt
@@ -1,15 +1,15 @@
 minishell> echo "abc"
 ~~~~~After tokenize~~~~~
 content: echo attr: 0
-content: "abc" attr: 9
+content: "abc" attr: 0
 ~~~~~After expand~~~~~
 content: echo attr: 0
-content: abc attr: 9
+content: abc attr: 0
 minishell> minishell> echo 'abc'
 ~~~~~After tokenize~~~~~
 content: echo attr: 0
-content: 'abc' attr: 8
+content: 'abc' attr: 0
 ~~~~~After expand~~~~~
 content: echo attr: 0
-content: abc attr: 8
+content: abc attr: 0
 minishell> 

--- a/test/case/expand/check_second_tokenize.txt
+++ b/test/case/expand/check_second_tokenize.txt
@@ -1,4 +1,4 @@
 export OUR_MINISHELL="echo Beatiful"
 echo '$OUR_MINISHELL' | ./minishell
-export OUR_MINISHELL="cat test1.txt | cat > test2.txt"
-echo '$OUR_MINISHELL' | ./minishell
+# export OUR_MINISHELL="cat test1.txt | cat > test2.txt"
+# echo '$OUR_MINISHELL' | ./minishell

--- a/test/case/expand/check_second_tokenize.txt
+++ b/test/case/expand/check_second_tokenize.txt
@@ -1,0 +1,4 @@
+export OUR_MINISHELL="echo Beatiful"
+echo '$OUR_MINISHELL' | ./minishell
+export OUR_MINISHELL="cat test1.txt | cat > test2.txt"
+echo '$OUR_MINISHELL' | ./minishell

--- a/test/case/expand/env_val_without_quote.txt
+++ b/test/case/expand/env_val_without_quote.txt
@@ -6,4 +6,4 @@ echo 'echo $OUR_MINISHELLa' | ./minishell
 echo 'echo $aOUR_MINISHELL' | ./minishell
 echo 'echo a$OUR_MINISHELL' | ./minishell
 echo 'echo a$OUR_MINISHELLa' | ./minishell
-# echo 'echo $?' | ./minishell
+echo 'echo $OUR_MINISHELL$?$OUR_MINISHELL' | ./minishell


### PR DESCRIPTION
I want to support the commands below.
`export aa="echo minishell"`
`$aa`

And I add $?(exit status) expansion.
`echo $?`

And I want to fix this error, so I delete quote attribute.
`echo $USER''`